### PR TITLE
Set up GHA workflow_dispatch for config generation

### DIFF
--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -16,9 +16,11 @@ on:
         required: true
         default: 'test'
       report-date:
-        description: 'Report date (default: today)'
+        description: 'Report date (default: today; format: YYYY-MM-DD)'
+        default: null
+        required: true
       reference-dates:
-        description: 'Reference dates (default: [8 weeks before, 1 day before] report date)'
+        description: 'Reference dates (default: [8 weeks before, 1 day before] report date; format: YYYY-MM-DD, YYYY-MM-DD)'
       data-source:
         description: 'Data source (default: nssp)'
         required: true
@@ -29,7 +31,8 @@ on:
         default: 'gold/'
       data-container:
         description: 'Data path (default: None)'
-
+        required: true
+        default: null
 jobs:
 
   run-workload:
@@ -64,6 +67,6 @@ jobs:
 
       - name: Execute workload script
         run: |
-          state=${{ github.event.inputs.state }} \
-            disease=${{ github.event.inputs.disease}} \
+          state=${{ inputs.state }} \
+            disease=${{ inputs.disease}} \
             poetry run python pipelines/epinow2/generate_config.py

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: set pythonpath
         run: |
-          echo "$PWD"
+          echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
 
       - name: Execute workload script
         run: |

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -18,7 +18,7 @@ on:
       report-date:
         description: 'Report date (default: today)'
       reference-dates:
-        description: 'Reference dates (default: [8 weeks before, 1 day before] report date)
+        description: 'Reference dates (default: [8 weeks before, 1 day before] report date)'
       data-source:
         description: 'Data source (default: nssp)'
         required: true
@@ -27,7 +27,7 @@ on:
         description: 'Data path (default: gold/)'
         required: true
         default: 'gold/'
-      data-path:
+      data-container:
         description: 'Data path (default: None)'
 
 jobs:

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -58,6 +58,10 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: set pythonpath
+        run: |
+          echo "PYTHONPATH=cfa-config-generator" >> $GITHUB_ENV
+
       - name: Execute workload script
         run: |
           state=${{ github.event.inputs.state }} \

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: set pythonpath
         run: |
-          echo "PYTHONPATH=cfa-config-generator" >> $GITHUB_ENV
+          echo "$PWD"
 
       - name: Execute workload script
         run: |

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -1,0 +1,66 @@
+name: run-workload
+description: Run a workload to create a new modeling job and associated task configs
+
+on:
+  pull_request:
+  workflow_dispatch:
+    schedule:
+      - cron: '0 9 * * 3'
+    inputs:
+      state:
+        description: 'State to run (default: all)'
+        required: true
+        default: 'test'
+      disease:
+        description: 'Disease to run (default: all)'
+        required: true
+        default: 'test'
+      report-date:
+        description: 'Report date (default: today)'
+      reference-dates:
+        description: 'Reference dates (default: [8 weeks before, 1 day before] report date)
+      data-source:
+        description: 'Data source (default: nssp)'
+        required: true
+        default: 'nssp'
+      data-path:
+        description: 'Data path (default: gold/)'
+        required: true
+        default: 'gold/'
+      data-path:
+        description: 'Data path (default: None)'
+
+jobs:
+
+  run-workload:
+    runs-on: cfa-cdcgov
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: cache poetry
+        uses: actions/cache@v4
+        with:
+          path: ~/.local
+          key: ${{ runner.os }}-poetry
+
+      - name: install poetry
+        run: pip install poetry
+
+      - name: install dependencies
+        run: poetry install
+
+      - name: Azure Service Principal CLI login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Execute workload script
+        run: |
+          state=${{ github.event.inputs.state }} \
+            disease=${{ github.event.inputs.disease}} \
+            poetry run python pipelines/epinow2.py
+
+

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -1,8 +1,7 @@
 name: run-workload
-description: Run a workload to create a new modeling job and associated task configs
+description: Run a workload to create a new modeling job and associated task configs.
 
 on:
-  pull_request:
   workflow_dispatch:
     schedule:
       - cron: '0 9 * * 3'
@@ -10,31 +9,33 @@ on:
       state:
         description: 'State to run (default: all)'
         required: true
-        default: 'test'
+        default: 'all'
       disease:
         description: 'Disease to run (default: all)'
         required: true
-        default: 'test'
-      report-date:
+        default: 'all'
+      report_date:
         description: 'Report date (default: today; format: YYYY-MM-DD)'
         default: null
         required: true
-      reference-dates:
+      reference_dates:
         description: 'Reference dates (default: [8 weeks before, 1 day before] report date; format: YYYY-MM-DD, YYYY-MM-DD)'
-      data-source:
+        default: null
+        required: true
+      data_source:
         description: 'Data source (default: nssp)'
         required: true
         default: 'nssp'
-      data-path:
+      data_path:
         description: 'Data path (default: gold/)'
         required: true
         default: 'gold/'
-      data-container:
+      data_container:
         description: 'Data path (default: None)'
         required: true
         default: null
-jobs:
 
+jobs:
   run-workload:
     runs-on: cfa-cdcgov
     environment: production
@@ -68,5 +69,10 @@ jobs:
       - name: Execute workload script
         run: |
           state=${{ inputs.state }} \
-            disease=${{ inputs.disease}} \
+          disease=${{ inputs.disease }} \
+          reference_dates=${{ inputs.reference_dates }} \
+          report_date=${{ inputs.report_date }} \
+          data_source=${{ inputs.data_source }} \
+          data_path=${{ inputs.data_path }} \
+          data_container=${{ inputs.data_container }} \
             poetry run python pipelines/epinow2/generate_config.py

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -62,5 +62,3 @@ jobs:
           state=${{ github.event.inputs.state }} \
             disease=${{ github.event.inputs.disease}} \
             poetry run python pipelines/epinow2.py
-
-

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -62,4 +62,4 @@ jobs:
         run: |
           state=${{ github.event.inputs.state }} \
             disease=${{ github.event.inputs.disease}} \
-            poetry run python pipelines/epinow2.py
+            poetry run python pipelines/epinow2/generate_config.py

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -34,6 +34,7 @@ jobs:
 
   run-workload:
     runs-on: cfa-cdcgov
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pipelines/epinow2/generate_config.py
+++ b/pipelines/epinow2/generate_config.py
@@ -27,7 +27,6 @@ if __name__ == "__main__":
 
     # Pull run parameters from environment
     user_args = extract_user_args()
-    print(user_args)
 
     # Validate and sanitize args
     sanitized_args = validate_args(**user_args)

--- a/pipelines/epinow2/generate_config.py
+++ b/pipelines/epinow2/generate_config.py
@@ -27,6 +27,7 @@ if __name__ == "__main__":
 
     # Pull run parameters from environment
     user_args = extract_user_args()
+    print(user_args)
 
     # Validate and sanitize args
     sanitized_args = validate_args(**user_args)


### PR DESCRIPTION
I'm not yet saying that this closes the related issue until it's fully tested in `main` -- I'm not actually sure how to test this in a PR as GHA doesn't seem to set the default inputs for the workflow unless it's manually triggered in the `main` branch. (see: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#defining-inputs-for-manually-triggered-workflows) 

But in theory, this should accept parameters from either a command line workflow dispatch or the GUI that will get populated once this PR is merged and create the job/task configs accordingly. I've also added a schedule to run at 5am EST every Wednesday (but can change that easily depending on project needs).