### PR TITLE
Use AzureCliCredential

### DIFF
--- a/utils/azure/auth.py
+++ b/utils/azure/auth.py
@@ -1,18 +1,18 @@
-from azure.identity import DefaultAzureCredential
+from azure.identity import AzureCliCredential
 
 
-def obtain_sp_credential() -> DefaultAzureCredential:
+def obtain_sp_credential() -> AzureCliCredential:
     """Obtains service principal credentials from Azure.
     Returns:
-        Instance of DefaultAzureCredential.
+        Instance of AzureCliCredential.
     Raises:
         LookupError if credential not found.
     """
 
-    # The DefaultAzureCredential reads from the environment directly
+    # The AzureCliCredential reads from the environment directly
     # if running locally. Check that SP credentials
     # are in environment if running locally.
     # Deployed versions use Managed Identity.
-    sp_credential = DefaultAzureCredential()
+    sp_credential = AzureCliCredential()
 
     return sp_credential


### PR DESCRIPTION
When running the workflow in GHA, we're getting an authorization error when uploading to blob storage. After debugging with @jkislin, we want to check if the `DefaultAzureCredential` is logging in with the GHA runner's SP instead of the CLI credentials that were provided in the previous workflow step. This change should allow us to explicitly use the NNH SP credentials and be able to push to storage. 