### PR TITLE
Update defaults + add production_date to schema

### DIFF
--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -8,32 +8,20 @@ on:
     inputs:
       state:
         description: 'State to run (default: all)'
-        required: true
-        default: 'all'
       disease:
         description: 'Disease to run (default: all)'
-        required: true
-        default: 'all'
       report_date:
         description: 'Report date (default: today; format: YYYY-MM-DD)'
-        default: null
-        required: true
       reference_dates:
         description: 'Reference dates (default: [8 weeks before, 1 day before] report date; format: YYYY-MM-DD, YYYY-MM-DD)'
-        default: null
-        required: true
       data_source:
         description: 'Data source (default: nssp)'
-        required: true
-        default: 'nssp'
       data_path:
         description: 'Data path (default: gold/)'
-        required: true
-        default: 'gold/'
       data_container:
         description: 'Data path (default: None)'
-        required: true
-        default: null
+      production_date:
+        description: 'Production date (default: the following Friday; format: YYYY-MM-DD)'
 
 jobs:
   run-workload:
@@ -75,4 +63,5 @@ jobs:
           data_source=${{ inputs.data_source }} \
           data_path=${{ inputs.data_path }} \
           data_container=${{ inputs.data_container }} \
+          production_date=${{ inputs.production_date }} \
             poetry run python pipelines/epinow2/generate_config.py

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -21,7 +21,7 @@ on:
       data_container:
         description: 'Data path (default: None)'
       production_date:
-        description: 'Production date (default: the following Friday; format: YYYY-MM-DD)'
+        description: 'Production date (default: today; format: YYYY-MM-DD)'
 
 jobs:
   run-workload:

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -16,6 +16,7 @@ def test_extract_user_args():
         "state": "all",
         "disease": "all",
         "report_date": date.today(),
+        "production_date": date.today(),
         "reference_dates": [min_reference_date, max_reference_date],
         "data_source": "nssp",
         "data_path": "gold/",
@@ -35,6 +36,7 @@ def test_validate_args_default():
         "state": "all",
         "disease": "all",
         "report_date": date.today(),
+        "production_date": date.today(),
         "reference_dates": [min_reference_date, max_reference_date],
         "data_source": "nssp",
         "data_path": "gold/",
@@ -49,6 +51,7 @@ def test_validate_args_default():
         "report_date": report_date,
         "data_path": "gold/",
         "data_container": None,
+        "production_date": date.today(),
     }
 
 
@@ -62,6 +65,7 @@ def test_invalid_state():
         "data_source": "nssp",
         "data_path": "gold/",
         "data_container": None,
+        "production_date": date.today(),
     }
     with pytest.raises(ValueError):
         validate_args(**args)
@@ -77,6 +81,7 @@ def test_invalid_disease():
         "data_source": "nssp",
         "data_path": "gold/",
         "data_container": None,
+        "production_date": date.today(),
     }
     with pytest.raises(ValueError):
         validate_args(**args)
@@ -92,6 +97,7 @@ def test_invalid_reference_date_format():
         "data_source": "nssp",
         "data_path": "gold/",
         "data_container": None,
+        "production_date": date.today(),
     }
     with pytest.raises(ValueError):
         validate_args(**args)
@@ -107,6 +113,7 @@ def test_invalid_reference_date_range():
         "data_source": "nssp",
         "data_path": "gold/",
         "data_container": None,
+        "production_date": date.today(),
     }
     with pytest.raises(ValueError):
         validate_args(**args)

--- a/tests/test_config_generation.py
+++ b/tests/test_config_generation.py
@@ -23,6 +23,7 @@ def test_default_config_set():
         "data_source": "nssp",
         "data_path": "gold/",
         "data_container": None,
+        "production_date": date.today(),
     }
     validated_args = validate_args(**default_args)
     as_of_date = generate_timestamp()
@@ -51,6 +52,7 @@ def test_single_geo_disease_set():
         "data_source": "nssp",
         "data_path": "gold/",
         "data_container": None,
+        "production_date": date.today(),
     }
     validated_args = validate_args(**default_args)
     as_of_date = generate_timestamp()

--- a/utils/epinow2/functions.py
+++ b/utils/epinow2/functions.py
@@ -39,6 +39,7 @@ def generate_timestamp() -> int:
     """Generates a timestamp of the current time using UTC timezone."""
     return int(datetime.timestamp(datetime.now(timezone.utc)))
 
+
 def get_reference_date_range(report_date: date) -> tuple[date, date]:
     """Returns a tuple of the minimum and maximum reference dates
     based on the report date, in the case that no reference_dates


### PR DESCRIPTION
-- Removes required parameters so that they don't need to be specified from the GUI; the underlying Python code should handle the case where no inputs are provided

-- Adding a production_date input field 

-- Updating tests