### PR TITLE
CLI Setup

### DIFF
--- a/cli/console.py
+++ b/cli/console.py
@@ -1,0 +1,2 @@
+def main():
+    print(">>> In confmod CLI.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,10 @@ authors = ["amondal2 <ab59@cdc.gov>"]
 license = "ASL"
 readme = "README.md"
 
+packages = [
+    { include = "cli" }
+]
+
 [tool.poetry.dependencies]
 python = "^3.10"
 azure-storage-blob = "^12.23.1"
@@ -20,3 +24,6 @@ pytest = "^8.3.3"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+confmod = "cli.console:main"


### PR DESCRIPTION
Leveraging poetry's script tag to configure a CLI called `confmod` in the repository. To test:

```
poetry install
confmod
```
or
```
poetry install
poetry run confmod
```