### PR TITLE
Job + task filter logic

### DIFF
--- a/cli/console.py
+++ b/cli/console.py
@@ -79,11 +79,11 @@ def list_tasks(
         ),
     ] = 10,
     state: Annotated[
-        str,
+        str | None,
         typer.Option("--state", "-s", help="State to filter tasks by (default all)."),
     ] = None,
     disease: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--disease",
             "-d",

--- a/cli/console.py
+++ b/cli/console.py
@@ -72,6 +72,24 @@ def list_tasks(
     job_id: Annotated[
         str, typer.Option("--job-id", "-j", help="Job ID to list tasks for")
     ],
+    num_tasks: Annotated[
+        int,
+        typer.Option(
+            "--num-tasks", "-n", help="Number of tasks to display (default 10)."
+        ),
+    ] = 10,
+    state: Annotated[
+        str,
+        typer.Option("--state", "-s", help="State to filter tasks by (default all)."),
+    ] = None,
+    disease: Annotated[
+        str,
+        typer.Option(
+            "--disease",
+            "-d",
+            help="Disease to filter tasks by (default COVID-19, Influenza).",
+        ),
+    ] = None,
 ):
     container_name = azure_storage["azure_container_name"]
     with console.status(
@@ -86,8 +104,10 @@ def list_tasks(
             )
             container_client = blob_service_client.get_container_client(container_name)
             blob_list = container_client.list_blobs()
-            tasks_for_job = get_tasks_for_job_id(blob_list=blob_list, job_id=job_id)
-            console.print(tasks_for_job)
+            tasks_for_job = get_tasks_for_job_id(
+                blob_list=blob_list, job_id=job_id, state=state, disease=disease
+            )
+            console.print(tasks_for_job[0:num_tasks])
         except (ResourceNotFoundError, ValueError, ClientAuthenticationError) as e:
             console.print(
                 "[italic red] :triangular_flag: Error instantiating blob client or finding specified resource."

--- a/cli/console.py
+++ b/cli/console.py
@@ -37,7 +37,14 @@ def check_login():
 
 
 @app.command("list-jobs")
-def list_jobs():
+def list_jobs(
+    num_jobs: Annotated[
+        int,
+        typer.Option(
+            "--num-jobs", "-n", help="Number of jobs to display (default 10)."
+        ),
+    ] = 10,
+):
     container_name = azure_storage["azure_container_name"]
     with console.status(
         f"Fetching jobs in {container_name} container...\n",
@@ -52,7 +59,7 @@ def list_jobs():
             container_client = blob_service_client.get_container_client(container_name)
             blob_list = container_client.list_blobs()
             unique_jobs = get_unique_jobs_from_blobs(blob_list=blob_list)
-            console.print(unique_jobs)
+            console.print(unique_jobs[0:num_jobs])
         except (ValueError, ResourceNotFoundError, ClientAuthenticationError) as e:
             console.print(
                 "[italic red] :triangular_flag: Error instantiating blob client or finding specified resource."

--- a/utils/azure/storage.py
+++ b/utils/azure/storage.py
@@ -45,7 +45,12 @@ def get_unique_jobs_from_blobs(blob_list: list | None = None) -> list:
     return sorted(unique_jobs)
 
 
-def get_tasks_for_job_id(blob_list: list | None = None, job_id: str = "") -> list:
+def get_tasks_for_job_id(
+    blob_list: list | None = None,
+    job_id: str = "",
+    state: str | None = None,
+    disease: str | None = None,
+) -> list:
     """Function to extract tasks for a specific job ID from a list of blobs.
     Args:
         blob_list (list): List of blobs from Azure Storage.
@@ -64,6 +69,12 @@ def get_tasks_for_job_id(blob_list: list | None = None, job_id: str = "") -> lis
             raise ValueError(
                 "Blob name does not match expected format. Check that blobs are formatted as <job_id>/<task_id>.json."
             )
+    if state:
+        tasks_for_job = [task for task in tasks_for_job if state in task]
+
+    if disease:
+        tasks_for_job = [task for task in tasks_for_job if disease in task]
+
     return sorted(tasks_for_job)
 
 


### PR DESCRIPTION
Closes #21 --

- Adds an optional parameter to control how many jobs and tasks are displayed
- Adds optional parameters for filtering tasks by state and disease

Some commands for testing: 
```
confmod list-tasks -j Rt-estimation-bf57b6e297ad11efb20c00155d63cada-2024-10-31T17-29-56 -n 100 -d Influenza
confmod list-tasks -j Rt-estimation-bf57b6e297ad11efb20c00155d63cada-2024-10-31T17-29-56 -s CA -d COVID-19
confmod list-jobs -n 1
```