### PR TITLE
Config-level exclusion

### DIFF
--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -3,8 +3,6 @@ description: Run a workload to create a new modeling job and associated task con
 
 on:
   workflow_dispatch:
-    schedule:
-      - cron: '0 9 * * 3'
     inputs:
       state:
         description: 'State to run (default: all)'

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -91,4 +91,5 @@ modifiable_params = [
     "horizon",
     "priors",
     "sampler_opts",
+    "exclusions",
 ]

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -12,6 +12,9 @@ shared_params = {
         "adapt_delta": 0.99,
         "max_treedepth": 12,
     },
+    "exclusions": {
+        "path": None
+    }
 }
 
 all_states = [

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -14,7 +14,8 @@ shared_params = {
     },
     "exclusions": {
         "path": None
-    }
+    },
+    "config_version": "1.0",
 }
 
 all_states = [

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -12,9 +12,7 @@ shared_params = {
         "adapt_delta": 0.99,
         "max_treedepth": 12,
     },
-    "exclusions": {
-        "path": None
-    },
+    "exclusions": {"path": None},
     "config_version": "1.0",
 }
 

--- a/utils/epinow2/functions.py
+++ b/utils/epinow2/functions.py
@@ -236,7 +236,6 @@ def generate_task_configs(
                 "disease": d,
                 "geo_value": [s],
                 "geo_type": "state" if s != "US" else "country",
-                "parameters": shared_params["parameters"],
                 "data": {
                     "path": data_path,
                     "blob_storage_container": data_container,
@@ -244,10 +243,7 @@ def generate_task_configs(
                     "reference_date": [x.isoformat() for x in reference_dates],
                     "production_date": [production_date.isoformat()],
                 },
-                "seed": shared_params["seed"],
-                "horizon": shared_params["horizon"],
-                "priors": shared_params["priors"],
-                "sampler_opts": shared_params["sampler_opts"],
+                **shared_params,
             }
             configs.append(task_config)
     return configs, job_name


### PR DESCRIPTION
Closes #22 as we've decided that reporting exclusions won't be handled at the task level and will be managed in the output postprocessing.

This PR:
- Adds an exclusions field to the task config to manage point exclusions
- Removes the scheduled run (for now)
- Adds exclusion path to parameters that can be modified by the CLI 