### PR TITLE
Schema updates

### DIFF
--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -19,7 +19,7 @@ def test_extract_user_args():
         "production_date": date.today(),
         "reference_dates": [min_reference_date, max_reference_date],
         "data_source": "nssp",
-        "data_path": "gold/",
+        "data_path": f"gold/{report_date}.parquet",
         "data_container": None,
     }
 
@@ -39,7 +39,7 @@ def test_validate_args_default():
         "production_date": date.today(),
         "reference_dates": [min_reference_date, max_reference_date],
         "data_source": "nssp",
-        "data_path": "gold/",
+        "data_path": f"gold/{report_date}.parquet",
         "data_container": None,
     }
 
@@ -49,7 +49,7 @@ def test_validate_args_default():
         "disease": all_diseases,
         "reference_dates": [min_reference_date, max_reference_date],
         "report_date": report_date,
-        "data_path": "gold/",
+        "data_path": f"gold/{report_date}.parquet",
         "data_container": None,
         "production_date": date.today(),
     }

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -2,19 +2,10 @@ shared_params = {
     "seed": 42,
     "horizon": 14,
     "priors": {"rt": {"mean": 1.0, "sd": 0.2}, "gp": {"alpha_sd": 0.01}},
-     "parameters": {
-       "generation_interval": {
-         "path": "gold/",
-         "blob_storage_container": None
-       },
-       "delay_interval": {
-         "path": None,
-         "blob_storage_container": None
-       },
-       "right_truncation": {
-         "path": None,
-         "blob_storage_container": None
-       }
+    "parameters": {
+        "generation_interval": {"path": None, "blob_storage_container": None},
+        "delay_interval": {"path": None, "blob_storage_container": None},
+        "right_truncation": {"path": None, "blob_storage_container": None},
     },
     "sampler_opts": {
         "cores": 1,

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -2,11 +2,6 @@ shared_params = {
     "seed": 42,
     "horizon": 14,
     "priors": {"rt": {"mean": 1.0, "sd": 0.2}, "gp": {"alpha_sd": 0.01}},
-    "parameters": {
-        "generation_interval": {"path": None, "blob_storage_container": None},
-        "delay_interval": {"path": None, "blob_storage_container": None},
-        "right_truncation": {"path": None, "blob_storage_container": None},
-    },
     "sampler_opts": {
         "cores": 1,
         "chains": 1,

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -2,18 +2,32 @@ shared_params = {
     "seed": 42,
     "horizon": 14,
     "priors": {"rt": {"mean": 1.0, "sd": 0.2}, "gp": {"alpha_sd": 0.01}},
-    "parameters": {
-        "path": "data/parameters.parquet",
-        "blob_storage_container": None,
+     "parameters": {
+       "generation_interval": {
+         "path": "gold/",
+         "blob_storage_container": None
+       },
+       "delay_interval": {
+         "path": None,
+         "blob_storage_container": None
+       },
+       "right_truncation": {
+         "path": None,
+         "blob_storage_container": None
+       }
     },
     "sampler_opts": {
-        "cores": 4,
-        "chains": 4,
+        "cores": 1,
+        "chains": 1,
+        "iter_warmup": 50,
+        "iter_sampling": 50,
         "adapt_delta": 0.99,
         "max_treedepth": 12,
     },
     "exclusions": {"path": None},
     "config_version": "1.0",
+    "quantile_width": [0.5, 0.95],
+    "model": "EpiNow2",
 }
 
 all_states = [
@@ -90,4 +104,6 @@ modifiable_params = [
     "priors",
     "sampler_opts",
     "exclusions",
+    "quantile_width",
+    "model",
 ]

--- a/utils/epinow2/functions.py
+++ b/utils/epinow2/functions.py
@@ -23,7 +23,7 @@ def extract_user_args() -> dict:
     ]
 
     data_source = os.environ.get("data_source") or "nssp"
-    data_path = os.environ.get("data_path") or "gold/"
+    data_path = os.environ.get("data_path") or f"gold/{report_date}.parquet"
     data_container = os.environ.get("data_container") or None
     return {
         "state": state,

--- a/utils/epinow2/functions.py
+++ b/utils/epinow2/functions.py
@@ -234,7 +234,7 @@ def generate_task_configs(
                 "task_id": generate_task_id(job_id=job_id, state=s, disease=d),
                 "as_of_date": as_of_date,
                 "disease": d,
-                "geo_value": [s],
+                "geo_value": s,
                 "geo_type": "state" if s != "US" else "country",
                 "data": {
                     "path": data_path,

--- a/utils/epinow2/functions.py
+++ b/utils/epinow2/functions.py
@@ -232,7 +232,9 @@ def generate_task_configs(
             task_config = {
                 "job_id": job_name,
                 "task_id": generate_task_id(job_id=job_id, state=s, disease=d),
-                "as_of_date": as_of_date,
+                "as_of_date": date.fromtimestamp(as_of_date).isoformat(),
+                "min_reference_date": min(reference_dates).isoformat(),
+                "max_reference_date": max(reference_dates).isoformat(),
                 "disease": d,
                 "geo_value": s,
                 "geo_type": "state" if s != "US" else "country",

--- a/utils/epinow2/functions.py
+++ b/utils/epinow2/functions.py
@@ -238,12 +238,11 @@ def generate_task_configs(
                 "disease": d,
                 "geo_value": s,
                 "geo_type": "state" if s != "US" else "country",
+                "report_date": report_date.isoformat(),
+                "production_date": production_date.isoformat(),
                 "data": {
                     "path": data_path,
                     "blob_storage_container": data_container,
-                    "report_date": [report_date.isoformat()],
-                    "reference_date": [x.isoformat() for x in reference_dates],
-                    "production_date": [production_date.isoformat()],
                 },
                 **shared_params,
             }

--- a/utils/epinow2/functions.py
+++ b/utils/epinow2/functions.py
@@ -232,7 +232,6 @@ def generate_task_configs(
             task_config = {
                 "job_id": job_name,
                 "task_id": generate_task_id(job_id=job_id, state=s, disease=d),
-                "as_of_date": date.fromtimestamp(as_of_date).isoformat(),
                 "min_reference_date": min(reference_dates).isoformat(),
                 "max_reference_date": max(reference_dates).isoformat(),
                 "disease": d,
@@ -240,6 +239,15 @@ def generate_task_configs(
                 "geo_type": "state" if s != "US" else "country",
                 "report_date": report_date.isoformat(),
                 "production_date": production_date.isoformat(),
+                "parameters": {
+                    "as_of_date": date.fromtimestamp(as_of_date).isoformat(),
+                    "generation_interval": {
+                        "path": None,
+                        "blob_storage_container": None,
+                    },
+                    "delay_interval": {"path": None, "blob_storage_container": None},
+                    "right_truncation": {"path": None, "blob_storage_container": None},
+                },
                 "data": {
                     "path": data_path,
                     "blob_storage_container": data_container,


### PR DESCRIPTION
Updating the config schema based on: https://github.com/CDCgov/cfa-epinow2-pipeline/blob/c9292dff551eba326dad62988beecb6b71f8a3c7/tests/testthat/data/sample_config.json

@zsusswein let me know if I missed anything. 

Added:
- generation_interval, delay_interval, right_trunction parameters
- iter_warmup, iter_sampling sampler opts
- converted as_of_date from timestamp back to iso format
- fields for min/max reference dates