### PR TITLE
Bump number of iterations

### DIFF
--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -6,7 +6,7 @@ shared_params = {
         "cores": 4,
         "chains": 4,
         "iter_warmup": 5000,
-        "iter_sampling": 10000, # 2500 x 4 chains
+        "iter_sampling": 10000,  # 2500 x 4 chains
         "adapt_delta": 0.99,
         "max_treedepth": 12,
     },

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -5,8 +5,8 @@ shared_params = {
     "sampler_opts": {
         "cores": 4,
         "chains": 4,
-        "iter_warmup": 2500,
-        "iter_sampling": 2500,
+        "iter_warmup": 5000,
+        "iter_sampling": 10000, # 2500 x 4 chains
         "adapt_delta": 0.99,
         "max_treedepth": 12,
     },


### PR DESCRIPTION
Did a test run expecting to see 2500 warmup and 2500 sampling iterations per chain.
Instead, we see 2500 warmup iterations per chain 2500 sampling iterations _total_.

Here, I bump this default to be 2500 * 4 = 10000 sampling iterations.
I also bump the warmup iterations default because the models are running quickly.
