### PR TITLE
Functionality to bulk update tasks

### DIFF
--- a/cli/console.py
+++ b/cli/console.py
@@ -175,7 +175,7 @@ def modify_task(
             ):
                 # Update timestamps and push to Azure
                 timestamp = generate_timestamp()
-                full_config["as_of_date"] = timestamp
+                full_config["parameters"]["as_of_date"] = timestamp
                 updated_task_id = update_task_id(full_config["task_id"], timestamp)
                 task_path = f"{job_id}/{updated_task_id}.json"
                 storage_client = instantiate_blob_service_client(
@@ -241,7 +241,7 @@ def bulk_update(
 
                     # Update timestamps and push to Azure
                     timestamp = generate_timestamp()
-                    updated_config["as_of_date"] = timestamp
+                    updated_config["parameters"]["as_of_date"] = timestamp
                     updated_task_id = update_task_id(
                         updated_config["task_id"], timestamp
                     )

--- a/cli/console.py
+++ b/cli/console.py
@@ -13,8 +13,11 @@ from utils.azure.storage import (
     get_unique_jobs_from_blobs,
     instantiate_blob_service_client,
 )
-from utils.cli.functions import update_config
-from utils.epinow2.constants import azure_storage, modifiable_params
+from utils.cli.functions import (
+    update_config,
+    update_config_bulk,
+)
+from utils.epinow2.constants import azure_storage, modifiable_params, sample_task
 from utils.epinow2.functions import generate_timestamp, update_task_id
 
 app = typer.Typer()
@@ -117,9 +120,7 @@ def list_tasks(
 
 @app.command("inspect-task")
 def inspect_task(
-    job_id: Annotated[
-        str, typer.Option("--job-id", "-j", help="Job ID of task")
-    ],
+    job_id: Annotated[str, typer.Option("--job-id", "-j", help="Job ID of task")],
     task_filename: Annotated[
         str, typer.Option("--task-filename", "-t", help="Task filename to inspect")
     ],
@@ -145,9 +146,7 @@ def inspect_task(
 
 @app.command("modify-task")
 def modify_task(
-    job_id: Annotated[
-        str, typer.Option("--job-id", "-j", help="Job ID of task")
-    ],
+    job_id: Annotated[str, typer.Option("--job-id", "-j", help="Job ID of task")],
     task_filename: Annotated[
         str, typer.Option("--task-filename", "-t", help="Task filename to modify")
     ],
@@ -203,11 +202,39 @@ def modify_task(
         )
         raise e
 
+
 @app.command("bulk-update")
 def bulk_update(
-    job_id: Annotated[str, typer.Option("--job-id", "-j", help="Job ID to update tasks for")]
+    job_id: Annotated[
+        str, typer.Option("--job-id", "-j", help="Job ID to update tasks for")
+    ],
 ):
-    console.print(f"[bold red] :loudspeaker: This command will modify all tasks for {job_id}. Proceed with caution.")
+    console.print(
+        f"[bold red] :loudspeaker: This command will modify all tasks for {job_id}. Proceed with caution."
+    )
+    sp_credential = obtain_sp_credential()
+    container_name = azure_storage["azure_container_name"]
+    try:
+        updated_config = update_config_bulk(sample_task, modifiable_params, console)
+        if updated_config:
+            # If there are updates, download all of the existing tasks for the job,
+            # update the fields, and generate new tasks with updated timestamps
+            blob_service_client = instantiate_blob_service_client(
+                sp_credential=sp_credential,
+                account_url=azure_storage["azure_storage_account_url"],
+            )
+            container_client = blob_service_client.get_container_client(container_name)
+            blob_list = container_client.list_blobs()
+            tasks_for_job = get_tasks_for_job_id(blob_list=blob_list, job_id=job_id)
+            print(tasks_for_job)
+        else:
+            console.print("No changes made to task configuration. Exiting.\n")
+    except (ResourceNotFoundError, ValueError, ClientAuthenticationError) as e:
+        console.print(
+            "[italic red] :triangular_flag: Error instantiating blob client or finding specified resource."
+        )
+        raise e
+
 
 def main():
     app()

--- a/cli/console.py
+++ b/cli/console.py
@@ -118,7 +118,7 @@ def list_tasks(
 @app.command("inspect-task")
 def inspect_task(
     job_id: Annotated[
-        str, typer.Option("--job-id", "-j", help="Job ID to list tasks for")
+        str, typer.Option("--job-id", "-j", help="Job ID of task")
     ],
     task_filename: Annotated[
         str, typer.Option("--task-filename", "-t", help="Task filename to inspect")
@@ -146,10 +146,10 @@ def inspect_task(
 @app.command("modify-task")
 def modify_task(
     job_id: Annotated[
-        str, typer.Option("--job-id", "-j", help="Job ID to list tasks for")
+        str, typer.Option("--job-id", "-j", help="Job ID of task")
     ],
     task_filename: Annotated[
-        str, typer.Option("--task-filename", "-t", help="Task filename to inspect")
+        str, typer.Option("--task-filename", "-t", help="Task filename to modify")
     ],
 ):
     sp_credential = obtain_sp_credential()
@@ -203,6 +203,11 @@ def modify_task(
         )
         raise e
 
+@app.command("bulk-update")
+def bulk_update(
+    job_id: Annotated[str, typer.Option("--job-id", "-j", help="Job ID to update tasks for")]
+):
+    console.print(f"[bold red] :loudspeaker: This command will modify all tasks for {job_id}. Proceed with caution.")
 
 def main():
     app()

--- a/cli/console.py
+++ b/cli/console.py
@@ -232,8 +232,8 @@ def bulk_update(
                 )
                 blob_list = container_client.list_blobs()
                 tasks_for_job = get_tasks_for_job_id(blob_list=blob_list, job_id=job_id)
-                for task_path in tasks_for_job:
-                    full_blob_path = f"{job_id}/{task_path}"
+                for task_filename in tasks_for_job:
+                    full_blob_path = f"{job_id}/{task_filename}"
                     blob_data = download_blob(
                         blob_path=full_blob_path, sp_credential=sp_credential
                     )

--- a/cli/console.py
+++ b/cli/console.py
@@ -232,7 +232,7 @@ def bulk_update(
                 )
                 blob_list = container_client.list_blobs()
                 tasks_for_job = get_tasks_for_job_id(blob_list=blob_list, job_id=job_id)
-                for task_path in tasks_for_job[0:10]:
+                for task_path in tasks_for_job:
                     full_blob_path = f"{job_id}/{task_path}"
                     blob_data = download_blob(
                         blob_path=full_blob_path, sp_credential=sp_credential

--- a/utils/cli/functions.py
+++ b/utils/cli/functions.py
@@ -61,6 +61,64 @@ def update_config(
     return updated_config
 
 
+def update_config_bulk(
+    config: dict | None = None,
+    keys: list | None = None,
+    console: Console | None = None,
+    updated_config: dict | None = None,
+) -> dict:
+    """Function that interactively and recursively updates a configuration,
+    based on user input. This is slightly different from the update_config, which
+    allows users to update any field in one task. This function keeps track of
+    requested updates to all tasks and applies them downstream.
+    Args:
+        config (dict): Configuration object to update.
+        keys (list): List of keys to update.
+        console (Console): Rich console object for printing.
+        updated_config (dict): Updated configuration object.
+    Returns:
+        dict: Updated configuration object.
+    """
+
+    # Initialize updated_config if this is the top-level call
+    if updated_config is None:
+        updated_config = {}
+
+    for key in keys:
+        to_modify = Confirm.ask(
+            f":key: Would you like to modify [bold green]{key}[/bold green]?"
+        )
+
+        if to_modify:
+            val_to_modify = config.get(key)
+            console.print("[bold] :pencil: Modifying:\n")
+            console.print(val_to_modify)
+
+            if isinstance(val_to_modify, dict):
+                # Handle nested dictionary
+                updated_config[key] = {}
+                update_config(
+                    val_to_modify, val_to_modify.keys(), console, updated_config[key]
+                )
+            elif isinstance(val_to_modify, list):
+                # Handle list inputs (reference_date, report_date, production_date)
+                prompt = get_prompt_from_type(val_to_modify)
+                new_val = prompt.ask(
+                    f":key: Enter new value for {key}; separate by commas for multiple values"
+                )
+                # Sanitize and store input as list
+                new_val = [x.strip() for x in new_val.split(",")]
+                updated_config[key] = new_val
+                console.print(f":light_bulb: Updated {key} to: {new_val}")
+            else:
+                prompt = get_prompt_from_type(val_to_modify)
+                new_val = prompt.ask(f":key: Enter new value for {key}")
+                updated_config[key] = new_val
+                console.print(f":light_bulb: Updated {key} to: {new_val}")
+
+    return updated_config
+
+
 def get_prompt_from_type(val: str = "") -> Prompt:
     """Function to return the correct type of Prompt
     to preserve the data type of the input.

--- a/utils/cli/functions.py
+++ b/utils/cli/functions.py
@@ -101,13 +101,13 @@ def update_config_bulk(
                     val_to_modify, val_to_modify.keys(), console, updated_config[key]
                 )
             elif isinstance(val_to_modify, list):
-                # Handle list inputs (reference_date, report_date, production_date)
+                # Handle list inputs (quantile_width)
                 prompt = get_prompt_from_type(val_to_modify)
                 new_val = prompt.ask(
                     f":key: Enter new value for {key}; separate by commas for multiple values"
                 )
                 # Sanitize and store input as list
-                new_val = [x.strip() for x in new_val.split(",")]
+                new_val = [float(x.strip()) for x in new_val.split(",")]
                 updated_config[key] = new_val
                 console.print(f":light_bulb: Updated {key} to: {new_val}")
             else:

--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -93,3 +93,49 @@ modifiable_params = [
     "quantile_width",
     "model",
 ]
+
+sample_task = {
+    "job_id": "sample-job-id",
+    "task_id": "sample-task-id",
+    "min_reference_date": "2024-10-22",
+    "max_reference_date": "2024-12-16",
+    "disease": "COVID-19",
+    "geo_value": "AK",
+    "geo_type": "state",
+    "report_date": "2024-12-17",
+    "production_date": "2024-12-17",
+    "parameters": {
+        "as_of_date": "2024-12-17T19:50:06.000814+00:00",
+        "generation_interval": {
+            "path": "prod.parquet",
+            "blob_storage_container": "prod-param-estimates",
+        },
+        "delay_interval": {
+            "path": "prod.parquet",
+            "blob_storage_container": "prod-param-estimates",
+        },
+        "right_truncation": {
+            "path": "prod.parquet",
+            "blob_storage_container": "prod-param-estimates",
+        },
+    },
+    "data": {
+        "path": "gold/2024-12-17.parquet",
+        "blob_storage_container": "nssp-etl",
+    },
+    "seed": 42,
+    "horizon": 14,
+    "priors": {"rt": {"mean": 1.0, "sd": 0.2}, "gp": {"alpha_sd": 0.01}},
+    "sampler_opts": {
+        "cores": 4,
+        "chains": 4,
+        "iter_warmup": 5000,
+        "iter_sampling": 10000,
+        "adapt_delta": 0.99,
+        "max_treedepth": 12,
+    },
+    "exclusions": {"path": None},
+    "config_version": "1.0",
+    "quantile_width": [0.5, 0.95],
+    "model": "EpiNow2",
+}

--- a/utils/epinow2/functions.py
+++ b/utils/epinow2/functions.py
@@ -185,10 +185,10 @@ def update_task_id(
         timestamp: updated timestamp
     """
     try:
-        # Task id format: <job_id>_<state>_<disease>_<timestamp>
-        # eg bf57b6e297ad11efb20c00155d63cada_WY_Influenza_1730395796
-        job_id, state, disease, _ = task_id.split("_")
-        return f"{job_id}_{state}_{disease}_{timestamp}"
+        # Task id format: <state>_<disease>_<timestamp>_<job_id>
+        # eg WY_Influenza_1730395796_bf57b6e297ad11efb20c00155d63cada
+        state, disease, _, job_id = task_id.split("_")
+        return f"{state}_{disease}_{timestamp}_{job_id}"
     except ValueError:
         raise ValueError(
             "Task ID does not match expected format. Check that task IDs are formatted as <job_id>_<state>_<disease>_<timestamp>."


### PR DESCRIPTION
Closes #35 --

Adding a CLI command to recursively update task fields and apply them to _all_ tasks within a given `job_id`.  Also casting the list input for `quantile_width` to float. Running this on a full set of configs takes a bit of time (a couple of minutes), so I tested on a subset in this container: `rt-epinow2-config / Rt-estimation-2024-12-26T20-40-05.093193+00-00-9666be7ac3c911ef9673696322d524e5`

You can see that two sets of tasks were generated for each (state, disease) pair with an updated timestamp in the `as_of_date` and task filename. Feel free to stress test this and let me know if any issues come up!

The command is `poetry run confmod bulk-update -j <job_id>` 