### PR TITLE
Make job_id user-configurable

### DIFF
--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -20,6 +20,8 @@ on:
         description: 'Data path (default: None)'
       production_date:
         description: 'Production date (default: today; format: YYYY-MM-DD)'
+      job_id:
+        description: 'Job ID (default: Rt-estimation-<timestamp>-<uuid>)'
 
 jobs:
   run-workload:
@@ -62,4 +64,5 @@ jobs:
           data_path=${{ inputs.data_path }} \
           data_container=${{ inputs.data_container }} \
           production_date=${{ inputs.production_date }} \
+          job_id=${{ inputs.job_id }} \
             poetry run python pipelines/epinow2/generate_config.py

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -3,44 +3,58 @@ from datetime import date, timedelta
 import pytest
 
 from utils.epinow2.constants import all_diseases, all_states, nssp_states_omit
-from utils.epinow2.functions import extract_user_args, validate_args
+from utils.epinow2.functions import (
+    extract_user_args,
+    generate_default_job_id,
+    generate_timestamp,
+    validate_args,
+)
 
 
 def test_extract_user_args():
     """Tests default set of extract_user_args."""
-    report_date = date.today()
+    report_date = production_date = date.today()
+    as_of_date = generate_timestamp()
     max_reference_date = report_date - timedelta(days=1)
     min_reference_date = report_date - timedelta(weeks=8)
 
     default_args = {
         "state": "all",
         "disease": "all",
-        "report_date": date.today(),
-        "production_date": date.today(),
+        "report_date": report_date,
+        "production_date": production_date,
         "reference_dates": [min_reference_date, max_reference_date],
         "data_source": "nssp",
         "data_path": f"gold/{report_date}.parquet",
         "data_container": "nssp-etl",
+        "job_id": generate_default_job_id(as_of_date=as_of_date),
+        "as_of_date": as_of_date,
     }
 
-    assert extract_user_args() == default_args
+    extracted_args = extract_user_args(as_of_date=as_of_date)
+
+    assert extracted_args.keys() == default_args.keys()
+    assert "Rt-estimation" in extracted_args["job_id"]
 
 
 def test_validate_args_default():
     """Tests validate_args with default arguments."""
-    report_date = date.today()
+    report_date = production_date = date.today()
+    as_of_date = generate_timestamp()
     max_reference_date = report_date - timedelta(days=1)
     min_reference_date = report_date - timedelta(weeks=8)
 
     default_args = {
         "state": "all",
         "disease": "all",
-        "report_date": date.today(),
-        "production_date": date.today(),
+        "report_date": report_date,
+        "production_date": production_date,
         "reference_dates": [min_reference_date, max_reference_date],
         "data_source": "nssp",
         "data_path": f"gold/{report_date}.parquet",
         "data_container": None,
+        "job_id": "test-job-id",
+        "as_of_date": as_of_date,
     }
 
     validated_args = validate_args(**default_args)
@@ -52,6 +66,8 @@ def test_validate_args_default():
         "data_path": f"gold/{report_date}.parquet",
         "data_container": None,
         "production_date": date.today(),
+        "job_id": "test-job-id",
+        "as_of_date": as_of_date,
     }
 
 

--- a/tests/test_config_generation.py
+++ b/tests/test_config_generation.py
@@ -4,14 +4,14 @@ from utils.epinow2.constants import all_diseases, all_states, nssp_states_omit
 from utils.epinow2.functions import (
     generate_task_configs,
     generate_timestamp,
-    generate_uuid,
     validate_args,
 )
 
 
 def test_default_config_set():
     """Tests that the default set of configs is generated correctly."""
-    report_date = date.today()
+    report_date = production_date = date.today()
+    as_of_date = generate_timestamp()
     max_reference_date = report_date - timedelta(days=1)
     min_reference_date = report_date - timedelta(weeks=8)
 
@@ -23,15 +23,14 @@ def test_default_config_set():
         "data_source": "nssp",
         "data_path": "gold/",
         "data_container": None,
-        "production_date": date.today(),
+        "production_date": production_date,
+        "job_id": "test-job-id",
+        "as_of_date": as_of_date,
     }
     validated_args = validate_args(**default_args)
-    as_of_date = generate_timestamp()
-    job_id = generate_uuid()
+
     # Generate task-specific configs
-    task_configs, _ = generate_task_configs(
-        **validated_args, as_of_date=as_of_date, job_id=job_id
-    )
+    task_configs, _ = generate_task_configs(**validated_args)
     total_tasks_expected = len(set(all_states).difference(nssp_states_omit)) * len(
         all_diseases
     )
@@ -40,7 +39,8 @@ def test_default_config_set():
 
 def test_single_geo_disease_set():
     """Tests that a single geography-disease combination returns a single task."""
-    report_date = date.today()
+    report_date = production_date = date.today()
+    as_of_date = generate_timestamp()
     max_reference_date = report_date - timedelta(days=1)
     min_reference_date = report_date - timedelta(weeks=8)
 
@@ -52,14 +52,13 @@ def test_single_geo_disease_set():
         "data_source": "nssp",
         "data_path": "gold/",
         "data_container": None,
-        "production_date": date.today(),
+        "production_date": production_date,
+        "job_id": "test-job-id",
+        "as_of_date": as_of_date,
     }
     validated_args = validate_args(**default_args)
-    as_of_date = generate_timestamp()
-    job_id = generate_uuid()
+
     # Generate task-specific configs
-    task_configs, _ = generate_task_configs(
-        **validated_args, as_of_date=as_of_date, job_id=job_id
-    )
+    task_configs, _ = generate_task_configs(**validated_args)
     total_tasks_expected = 1
     assert len(task_configs) == total_tasks_expected


### PR DESCRIPTION
Closes #37 -- 

Adds functionality to allow the user to specify the job_id, so it can be managed by the pipeline runner in cfa-epinow2-pipeline. Additionally:
  - Removes distinction between "job name" and "job id"
  - Updates GH workflow file
  - Cleans up and updates tests
  - Removes job_id from task filename  