### PR TITLE
Use fewer draws by default

### DIFF
--- a/utils/epinow2/constants.py
+++ b/utils/epinow2/constants.py
@@ -6,7 +6,7 @@ shared_params = {
         "cores": 4,
         "chains": 4,
         "iter_warmup": 5000,
-        "iter_sampling": 10000,  # 2500 x 4 chains
+        "iter_sampling": 4000,  # 1000 draws per chain
         "adapt_delta": 0.99,
         "max_treedepth": 12,
     },


### PR DESCRIPTION
Decrease from 2500 draws per chain to 1000. This change corresponds
to a decrease of 10000 total draws to 4000 total draws.

This change should speed up downstream post-processing of model results.
