### PR TITLE
Update default output container

### DIFF
--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -21,7 +21,7 @@ on:
       task_exclusions:
         description: 'Task exclusions (state:disease pair - default: None; ex: NY:COVID-19)'
       output_container:
-        description: 'Output container in Azure (default: zs-test-pipeline-update)'
+        description: 'Output container in Azure (default: nssp-rt-testing)'
 
 jobs:
   run-workload:

--- a/src/cfa_config_generator/utils/epinow2/functions.py
+++ b/src/cfa_config_generator/utils/epinow2/functions.py
@@ -28,7 +28,7 @@ def extract_user_args(as_of_date: str) -> dict:
 
     data_path = f"gold/{report_date}.parquet"
     data_container = os.getenv("data_container") or "nssp-etl"
-    output_container = os.getenv("output_container") or "zs-test-pipeline-update"
+    output_container = os.getenv("output_container") or "nssp-rt-testing"
     job_id = os.getenv("job_id") or generate_default_job_id(as_of_date=as_of_date)
     return {
         "task_exclusions": task_exclusions,


### PR DESCRIPTION
## Goal
We want the config generator to send outputs to the `nssp-rt-testing` container by default. 

In a separate [PR](https://github.com/CDCgov/cfa-epinow2-pipeline/pull/218), we have edited the makefile in the cfa-epinow2-pipeline repo to set the output container to `nssp-rt-v2` for production runs. We don't want the production container to be the default, however, to avoid contaminating production outputs with test or experimental outputs.

## Changes
- Replaced all instances of `zs-test-pipeline-update` with `nssp-rt-testing`