### PR TITLE
Switching from self-hosted VM runner to ubuntu-latest

### DIFF
--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -102,5 +102,7 @@ jobs:
             --password ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).clientSecret }} \
             --tenant ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).tenantId }} 
 
-          az storage blob upload-batch -d ${{ inputs.output_container }} -s ${{ steps.get-folder-name.outputs.target_dir }}/
+          az storage blob upload-batch \
+          --destination https://cfaazurebatchprd.blob.core.windows.net/rt-epinow2-config \
+          --source ${{ steps.get-folder-name.outputs.target_dir }}/
 

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -82,7 +82,8 @@ jobs:
         print_logs: true
         script: | 
           # Fetch the artifact download URL
-          curl -H "Accept: application/vnd.github.v3+json" \
+          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }} \
+               -H "Accept: application/vnd.github.v3+json" \
                'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}/zip' -o artifact.zip
 
           # Unzip the downloaded file

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -22,6 +22,7 @@ on:
         description: 'Task exclusions (state:disease pair - default: None; ex: NY:COVID-19)'
       output_container:
         description: 'Output container in Azure (default: nssp-rt-testing)'
+        default: nssp-rt-testing
 
 jobs:
   run-workload:
@@ -62,11 +63,42 @@ jobs:
 
     - name: Zip folder
       run: |
-        zip -r ${{ steps.get-folder-name.outputs.target_dir }}.zip target/${{ steps.get-folder-name.outputs.target_dir }}
+        cd target && zip -r ../${{ steps.get-folder-name.outputs.target_dir }}.zip ${{ steps.get-folder-name.outputs.target_dir }} && cd ..
 
     - name: Upload Artifacts
+      id: upload-artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.get-folder-name.outputs.target_dir }}
         path: ${{ steps.get-folder-name.outputs.target_dir }}.zip
         retention-days: 1
+
+    - name: Copy to Azure Blob
+      uses: CDCgov/cfa-actions/runner-action@runner-action
+      with:
+        github_app_id: ${{ secrets.CDCENT_ACTOR_APP_ID }}
+        github_app_pem: ${{ secrets.CDCENT_ACTOR_APP_PEM }}
+        wait_for_completion: true
+        print_logs: true
+        script: | 
+          # Fetch the artifact download URL
+          ARTIFACT_URL=$(curl -s -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+                             -H "Accept: application/vnd.github.v3+json" \
+                             '${{ steps.upload-artifacts.outputs.artifact-url }}' | \
+                             jq -r '.artifacts[] | select(.name == "${{ steps.get-folder-name.outputs.target_dir}}.zip") | .archive_download_url')
+
+          # Download the artifact (as a zip file)
+          curl -L -o artifact.zip -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "$ARTIFACT_URL"
+
+          # Unzip the downloaded file
+          unzip artifact.zip -d out
+
+          # checking contents of out directory
+          ls -lah out
+
+          echo "Login to Azure with NNH Service Principal"
+          az login --service-principal \
+            --username ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).clientId }} \
+            --password ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).clientSecret }} \
+            --tenant ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).tenantId }} 
+

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -94,7 +94,7 @@ jobs:
           unzip artifact.zip
 
           # Unzip artifact
-          unzip ${{ steps.get-folder-name.outputs.target_dir }}.zip
+          unzip ${{ steps.get-folder-name.outputs.target_dir }}.zip -d artifacts
 
           echo "Login to Azure with NNH Service Principal"
           az login --service-principal \
@@ -104,5 +104,5 @@ jobs:
 
           az storage blob upload-batch \
           --destination https://cfaazurebatchprd.blob.core.windows.net/rt-epinow2-config \
-          --source ${{ steps.get-folder-name.outputs.target_dir }}/
+          --source artifacts/
 

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -22,7 +22,6 @@ on:
         description: 'Task exclusions (state:disease pair - default: None; ex: NY:COVID-19)'
       output_container:
         description: 'Output container in Azure (default: nssp-rt-testing)'
-        default: nssp-rt-testing
 
 jobs:
   run-workload:

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -81,11 +81,16 @@ jobs:
         wait_for_completion: true
         print_logs: true
         script: | 
+          echo "artifact-url='${{ steps.upload-artifacts.outputs.artifact-url }}'"
+
           # Fetch the artifact download URL
-          ARTIFACT_URL=$(curl -s -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          GET_ARTIFACTS_RES=$(curl -s -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
                              -H "Accept: application/vnd.github.v3+json" \
-                             '${{ steps.upload-artifacts.outputs.artifact-url }}' | \
-                             jq -r '.artifacts[] | select(.name == "${{ steps.get-folder-name.outputs.target_dir}}.zip") | .archive_download_url')
+                             '${{ steps.upload-artifacts.outputs.artifact-url }}')
+          echo "GET_ARTIFACTS_RES='$GET_ARTIFACTS_RES'"
+
+          ARTIFACT_URL=$(echo "$GET_ARTIFACTS_RES" | jq -r '.artifacts[] | select(.name == "${{ steps.get-folder-name.outputs.target_dir}}.zip") | .archive_download_url')
+          echo "ARTIFACT_URL='$ARTIFACT_URL'"
 
           # Download the artifact (as a zip file)
           curl -L -o artifact.zip -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "$ARTIFACT_URL"

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -74,7 +74,7 @@ jobs:
         retention-days: 1
 
     - name: Copy to Azure Blob
-      uses: CDCgov/cfa-actions/runner-action@runner-action
+      uses: CDCgov/cfa-actions/runner-action@v1.3.0
       with:
         github_app_id: ${{ secrets.CDCENT_ACTOR_APP_ID }}
         github_app_pem: ${{ secrets.CDCENT_ACTOR_APP_PEM }}

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -1,7 +1,11 @@
 name: run-workload
 description: Run a workload to create a new modeling job and associated task configs.
 
+# TODO: remove on: push:!
 on:
+  push:
+    branches:
+      - gio-runner-migration
   workflow_dispatch:
     inputs:
       state:
@@ -82,9 +86,11 @@ jobs:
         print_logs: true
         script: | 
           # Fetch the artifact download URL
-          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
                -H "Accept: application/vnd.github.v3+json" \
                'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}/zip' -o artifact.zip
+
+          cat artifact.zip
 
           # Unzip the downloaded file
           unzip artifact.zip -d out

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -1,11 +1,7 @@
 name: run-workload
 description: Run a workload to create a new modeling job and associated task configs.
 
-# TODO: remove on: push:!
 on:
-  push:
-    branches:
-      - gio-runner-migration
   workflow_dispatch:
     inputs:
       state:
@@ -85,15 +81,15 @@ jobs:
         wait_for_completion: true
         print_logs: true
         script: | 
-          # Fetch the artifact download URL
+          echo "Fetching artifacts"
           curl -L -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
                -H "Accept: application/vnd.github.v3+json" \
                'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}/zip' -o artifact.zip
 
-          # Unzip the downloaded file
+          echo "Unzipping download"
           unzip artifact.zip
 
-          # Unzip artifact
+          echo "Unzipping artifacts"
           unzip ${{ steps.get-folder-name.outputs.target_dir }}.zip -d artifacts
 
           echo "Login to Azure with NNH Service Principal"
@@ -102,6 +98,7 @@ jobs:
             --password ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).clientSecret }} \
             --tenant ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).tenantId }} 
 
+          echo "Uploading config to Azure Blob"
           az storage blob upload-batch \
           --destination https://cfaazurebatchprd.blob.core.windows.net/rt-epinow2-config \
           --source artifacts/

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -86,11 +86,9 @@ jobs:
         print_logs: true
         script: | 
           # Fetch the artifact download URL
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          curl -L -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
                -H "Accept: application/vnd.github.v3+json" \
                'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}/zip' -o artifact.zip
-
-          cat artifact.zip
 
           # Unzip the downloaded file
           unzip artifact.zip -d out

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -86,7 +86,7 @@ jobs:
           # Fetch the artifact download URL
           GET_ARTIFACTS_RES=$(curl -s -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
                              -H "Accept: application/vnd.github.v3+json" \
-                             'https://github.com/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}')
+                             'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}')
           echo "GET_ARTIFACTS_RES='$GET_ARTIFACTS_RES'"
 
           ARTIFACT_URL=$(echo "$GET_ARTIFACTS_RES" | jq -r '.artifacts[] | select(.name == "${{ steps.get-folder-name.outputs.target_dir}}.zip") | .archive_download_url')

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -81,19 +81,9 @@ jobs:
         wait_for_completion: true
         print_logs: true
         script: | 
-          echo "artifact-id='${{ steps.upload-artifacts.outputs.artifact-id }}'"
-
           # Fetch the artifact download URL
-          GET_ARTIFACTS_RES=$(curl -s -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-                             -H "Accept: application/vnd.github.v3+json" \
-                             'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}')
-          echo "GET_ARTIFACTS_RES='$GET_ARTIFACTS_RES'"
-
-          ARTIFACT_URL=$(echo "$GET_ARTIFACTS_RES" | jq -r '.artifacts[] | select(.name == "${{ steps.get-folder-name.outputs.target_dir}}.zip") | .archive_download_url')
-          echo "ARTIFACT_URL='$ARTIFACT_URL'"
-
-          # Download the artifact (as a zip file)
-          curl -L -o artifact.zip -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "$ARTIFACT_URL"
+          curl -H "Accept: application/vnd.github.v3+json" \
+               'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}/zip' -o artifact.zip
 
           # Unzip the downloaded file
           unzip artifact.zip -d out

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -60,9 +60,13 @@ jobs:
         child_name=$(basename "$child_dir")
         echo "target_dir=$child_name" >> $GITHUB_OUTPUT
 
+    - name: Zip folder
+      run: |
+        zip -r ${{ steps.get-folder-name.outputs.target_dir }}.zip target/{{ steps.get-folder-name.outputs.target_dir }}
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.get-folder-name.outputs.target_dir }}
-        path: target/${{ steps.get-folder-name.outputs.target_dir }}/
+        path: ${{ steps.get-folder-name.outputs.target_dir }}.zip
         retention-days: 1

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -91,10 +91,13 @@ jobs:
                'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}/zip' -o artifact.zip
 
           # Unzip the downloaded file
-          unzip artifact.zip -d out
+          unzip artifact.zip
+
+          # Unzip artifact
+          unzip ${{ steps.get-folder-name.outputs.target_dir }}.zip
 
           # checking contents of out directory
-          ls -lah out
+          ls -lah ${{ steps.get-folder-name.outputs.target_dir }}
 
           echo "Login to Azure with NNH Service Principal"
           az login --service-principal \

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -81,12 +81,12 @@ jobs:
         wait_for_completion: true
         print_logs: true
         script: | 
-          echo "artifact-url='${{ steps.upload-artifacts.outputs.artifact-url }}'"
+          echo "artifact-id='${{ steps.upload-artifacts.outputs.artifact-id }}'"
 
           # Fetch the artifact download URL
           GET_ARTIFACTS_RES=$(curl -s -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
                              -H "Accept: application/vnd.github.v3+json" \
-                             '${{ steps.upload-artifacts.outputs.artifact-url }}')
+                             'https://github.com/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}')
           echo "GET_ARTIFACTS_RES='$GET_ARTIFACTS_RES'"
 
           ARTIFACT_URL=$(echo "$GET_ARTIFACTS_RES" | jq -r '.artifacts[] | select(.name == "${{ steps.get-folder-name.outputs.target_dir}}.zip") | .archive_download_url')

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -56,7 +56,7 @@ jobs:
     - name: Get folder name
       id: get-folder-name
       run: |
-        child_dir=$(find "$target_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)
+        child_dir=$(find 'target' -mindepth 1 -maxdepth 1 -type d -print -quit)
         child_name=$(basename "$child_dir")
         echo "target_dir=$child_name" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -82,7 +82,7 @@ jobs:
         print_logs: true
         script: | 
           # Fetch the artifact download URL
-          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }} \
+          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
                -H "Accept: application/vnd.github.v3+json" \
                'https://api.github.com/repos/CDCgov/cfa-config-generator/actions/artifacts/${{ steps.upload-artifacts.outputs.artifact-id }}/zip' -o artifact.zip
 

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   run-workload:
-    runs-on: cfa-cdcgov
+    runs-on: ubuntu-latest
     environment: production
     steps:
     - uses: actions/checkout@v4
@@ -40,11 +40,6 @@ jobs:
       with:
         python-version-file: ".python-version"
 
-    - name: Azure Service Principal CLI login
-      uses: azure/login@v2
-      with:
-        creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
-
     - name: Execute workload script
       run: |
         state=${{ inputs.state }} \
@@ -56,4 +51,18 @@ jobs:
         job_id=${{ inputs.job_id }} \
         task_exclusions=${{ inputs.task_exclusions }} \
         output_container=${{ inputs.output_container }} \
-          uv run python pipelines/epinow2/generate_config.py
+          uv run python pipelines/epinow2/generate_config_local.py
+
+    - name: Get folder name
+      id: get-folder-name
+      run: |
+        child_dir=$(find "$target_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)
+        child_name=$(basename "$child_dir")
+        echo "target_dir=$child_name" >> $GITHUB_OUTPUT
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.get-folder-name.outputs.target_dir }}
+        path: target/${{ steps.get-folder-name.outputs.target_dir }}/
+        retention-days: 1

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -96,12 +96,11 @@ jobs:
           # Unzip artifact
           unzip ${{ steps.get-folder-name.outputs.target_dir }}.zip
 
-          # checking contents of out directory
-          ls -lah ${{ steps.get-folder-name.outputs.target_dir }}
-
           echo "Login to Azure with NNH Service Principal"
           az login --service-principal \
             --username ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).clientId }} \
             --password ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).clientSecret }} \
             --tenant ${{ fromJSON(secrets.EDAV_CFA_PREDICT_NNHT_SP).tenantId }} 
+
+          az storage blob upload-batch -d ${{ inputs.output_container }} -s ${{ steps.get-folder-name.outputs.target_dir }}/
 

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Zip folder
       run: |
-        zip -r ${{ steps.get-folder-name.outputs.target_dir }}.zip target/{{ steps.get-folder-name.outputs.target_dir }}
+        zip -r ${{ steps.get-folder-name.outputs.target_dir }}.zip target/${{ steps.get-folder-name.outputs.target_dir }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/pipelines/epinow2/generate_config_local.py
+++ b/pipelines/epinow2/generate_config_local.py
@@ -1,0 +1,65 @@
+import json
+import logging
+import os
+
+from cfa_config_generator.utils.azure.auth import obtain_sp_credential
+from cfa_config_generator.utils.azure.storage import instantiate_blob_service_client
+from cfa_config_generator.utils.epinow2.constants import azure_storage
+from cfa_config_generator.utils.epinow2.functions import (
+    extract_user_args,
+    generate_task_configs,
+    generate_timestamp,
+    validate_args,
+)
+
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    """
+    A script to generate `epinow2` configuration objects. This
+    will be invoked either by 1) a scheduled GH action using
+    default values, or 2) a user-triggered workflow with supplied
+    state, pathogen, report_date, and reference_date parameters.
+    This script is the entrypoint to the workflow that generates
+    configuration objects, validates them against a schema, and
+    writes them to a folder under the 'target/' directory.
+    """
+
+    # Generate job-specific parameters
+    as_of_date = generate_timestamp()
+
+    # Pull run parameters from environment
+    user_args = extract_user_args(as_of_date=as_of_date)
+
+    # Validate and sanitize args
+    sanitized_args = validate_args(**user_args)
+
+    # Generate task-specific configs
+    task_configs, job_id = generate_task_configs(**sanitized_args)
+
+    # Path to the 'output' directory
+    output_dir = f"target/{job_id}"
+
+    # Check if the directory exists
+    if os.path.exists(output_dir):
+        # Delete all files in the directory
+        for filename in os.listdir(output_dir):
+            file_path = os.path.join(output_dir, filename)
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+    else:
+        # Create the directory if it doesn't exist
+        os.makedirs(output_dir, exist_ok=True)
+
+    # Loop through the list and write each item to a new file
+    for task in task_configs:
+        file_name = f"{task['task_id']}.json"
+        file_path = os.path.join(output_dir, file_name)
+
+        # Write the item to the file
+        with open(file_path, 'w') as file:
+            file.write(json.dumps(task, indent=2))
+
+    logger.info(
+        f"Successfully generated configs for job; tasks stored in {job_id} directory."
+    )


### PR DESCRIPTION
The CDC Github team has requested that we stop using self-hosted runners for public (aka all cdcgov) repos. This PR addresses that request by using ubuntu-latest to generate the configs to a local directory, uploads the artifacts to Github, then uses the new [runner-action](https://github.com/CDCgov/cfa-actions/tree/main/runner-action) to download the artifacts and upload them to Azure blob storage

Here is a successful run: https://github.com/CDCgov/cfa-config-generator/actions/runs/13954159950/job/39060974486
![image](https://github.com/user-attachments/assets/75445e51-cb69-4c10-bc23-3ab364430ae1)

And in Blob Storage:
![image](https://github.com/user-attachments/assets/fab1e12e-d910-446d-bbf5-089fc90debdf)

Let me know if you have any questions
