### PR TITLE
Create default data exclusions path

### DIFF
--- a/.github/workflows/re-run-workload.yaml
+++ b/.github/workflows/re-run-workload.yaml
@@ -5,10 +5,10 @@ description: Run the re-run workload, which reads a data exclusion/outlier CSV a
 on:
   workflow_dispatch:
     inputs:
-      data_exclusions_path:
-        description: 'The path to the data exclusion CSV file. If in Blob, use form `az://<container-name>/<path>`'
       report_date:
         description: 'Report date (default: today; format: YYYY-MM-DD)'
+      data_exclusions_path:
+        description: 'The path to the data exclusion CSV file. If in Blob, use form `az://<container-name>/<path>` (default: `az://nssp-rt-v2/outliers/<report_date>.csv`)'
       reference_dates:
         description: 'Reference dates (default: [8 weeks before, 1 day before] report date; format: YYYY-MM-DD, YYYY-MM-DD)'
       data_container:


### PR DESCRIPTION
## Nate's Summary
After some discussion in the team, we decided to use a default value for the data exclusion path of `az://nssp-rt-v1/outliers/<report-date>.csv`. This PR 
- Sets the new default value if a path is not provided.
- Clarifies that in the workflow.

## Copilot's Summary
This pull request includes changes to the `re-run-workload` workflow and the `generate_rerun_config.py` script to improve the handling of the `data_exclusions_path` parameter by setting a default value and ensuring proper date formatting.

Improvements to `re-run-workload` workflow:

* [`.github/workflows/re-run-workload.yaml`](diffhunk://#diff-3d0c017934571bea10b6570c1866ec3f1fc963167fbc41128dc183d8b9b9df59L8-R11): Updated the `data_exclusions_path` input description to include a default value in the form `az://<container-name>/<path>` with the report date.

Enhancements to `generate_rerun_config.py` script:

* [`pipelines/epinow2/generate_rerun_config.py`](diffhunk://#diff-105225e9e4013c9d3e954143668f647a0fe6d67d6024d56dec0605f546dbd028R4): Added import for `date` from the `datetime` module.
* [`pipelines/epinow2/generate_rerun_config.py`](diffhunk://#diff-105225e9e4013c9d3e954143668f647a0fe6d67d6024d56dec0605f546dbd028L50-L62): Set a default value for `data_exclusions_path` using the report date if not found in the environment variables, ensuring the date is properly formatted.
* [`pipelines/epinow2/generate_rerun_config.py`](diffhunk://#diff-105225e9e4013c9d3e954143668f647a0fe6d67d6024d56dec0605f546dbd028R80): Moved the comment about downloading and reading the `data_exclusions` file to the appropriate location in the code.