### PR TITLE
running both workloads using runner-action

### DIFF
--- a/.github/workflows/re-run-workload.yaml
+++ b/.github/workflows/re-run-workload.yaml
@@ -67,10 +67,7 @@ jobs:
             --tenant ${{ secrets.AZ_TENANT_ID }} \
             --federated-token ${{ steps.idtoken.outputs.id_token }}
 
-          echo "Installing uv"
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          source $HOME/.local/bin/env
-
+          echo "Running workload"
           reference_dates=${{ inputs.reference_dates }} \
           report_date=${{ inputs.report_date }} \
           data_container=${{ inputs.data_container }} \

--- a/.github/workflows/re-run-workload.yaml
+++ b/.github/workflows/re-run-workload.yaml
@@ -22,33 +22,64 @@ on:
 
 jobs:
   run-workload:
-    runs-on: cfa-cdcgov
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    runs-on: ubuntu-latest
     environment: production
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      with:
-        enable-cache: true
+    # From: https://stackoverflow.com/a/58035262/2097171
+    - name: Extract branch name
+      shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      id: get-branch
 
-    - name: "Set up Python"
-      uses: actions/setup-python@v5
+    # From: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#requesting-the-jwt-using-the-actions-core-toolkit
+    - name: Install OIDC Client from Core Package
+      run: npm install @actions/core@1.6.0 @actions/http-client
+    - name: Get Id Token
+      uses: actions/github-script@v7
+      id: idtoken
       with:
-        python-version-file: ".python-version"
+        script: |
+          const coredemo = require('@actions/core')
+          const id_token = await coredemo.getIDToken('api://AzureADTokenExchange')
+          coredemo.setOutput('id_token', id_token)
 
-    - name: Azure Service Principal CLI login
-      uses: azure/login@v2
+    - name: Re-run workload
+      uses: CDCgov/cfa-actions/runner-action@v1.3.0
       with:
-        creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+        github_app_id: ${{ secrets.CDCENT_ACTOR_APP_ID }}
+        github_app_pem: ${{ secrets.CDCENT_ACTOR_APP_PEM }}
+        wait_for_completion: true
+        print_logs: true
+        script: |
+          CURRENT_BRANCH="${{ steps.get-branch.outputs.branch }}"
+          echo "Cloning repo at branch '$CURRENT_BRANCH'"
+          git clone -b "$CURRENT_BRANCH" https://github.com/${{ github.repository }}.git
+          cd cfa-config-generator
 
-    - name: Execute workload script
-      run: |
-        reference_dates=${{ inputs.reference_dates }} \
-        report_date=${{ inputs.report_date }} \
-        data_container=${{ inputs.data_container }} \
-        production_date=${{ inputs.production_date }} \
-        job_id=${{ inputs.job_id }} \
-        output_container=${{ inputs.output_container }} \
-        data_exclusions_path=${{ inputs.data_exclusions_path }} \
-          uv run python pipelines/epinow2/generate_rerun_config.py
+          echo "Logging into Azure CLI"
+          az login --output none --service-principal \
+            --username ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP_CLIENT_ID }} \
+            --tenant ${{ secrets.AZ_TENANT_ID }} \
+            --federated-token ${{ steps.idtoken.outputs.id_token }}
+
+          PYTHON_VERSION="$(cat .python-version)"
+          echo "Installing python $PYTHON_VERSION"
+          pyenv install "$PYTHON_VERSION"
+          pyenv local "$PYTHON_VERSION"
+
+          echo "Installing uv"
+          pip install uv
+
+          reference_dates=${{ inputs.reference_dates }} \
+          report_date=${{ inputs.report_date }} \
+          data_container=${{ inputs.data_container }} \
+          production_date=${{ inputs.production_date }} \
+          job_id=${{ inputs.job_id }} \
+          output_container=${{ inputs.output_container }} \
+          data_exclusions_path=${{ inputs.data_exclusions_path }} \
+            uv run python pipelines/epinow2/generate_rerun_config.py

--- a/.github/workflows/re-run-workload.yaml
+++ b/.github/workflows/re-run-workload.yaml
@@ -67,13 +67,9 @@ jobs:
             --tenant ${{ secrets.AZ_TENANT_ID }} \
             --federated-token ${{ steps.idtoken.outputs.id_token }}
 
-          PYTHON_VERSION="$(cat .python-version)"
-          echo "Installing python $PYTHON_VERSION"
-          pyenv install "$PYTHON_VERSION"
-          pyenv local "$PYTHON_VERSION"
-
           echo "Installing uv"
-          pip install uv
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          source $HOME/.local/bin/env
 
           reference_dates=${{ inputs.reference_dates }} \
           report_date=${{ inputs.report_date }} \

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -72,6 +72,7 @@ jobs:
 
           echo "Installing uv"
           curl -LsSf https://astral.sh/uv/install.sh | sh
+          source $HOME/.local/bin/env
 
           echo "Running workload"
           state=${{ inputs.state }} \

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -70,10 +70,6 @@ jobs:
             --tenant ${{ secrets.AZ_TENANT_ID }} \
             --federated-token ${{ steps.idtoken.outputs.id_token }}
 
-          echo "Installing uv"
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          source $HOME/.local/bin/env
-
           echo "Running workload"
           state=${{ inputs.state }} \
           disease=${{ inputs.disease }} \

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -70,13 +70,8 @@ jobs:
             --tenant ${{ secrets.AZ_TENANT_ID }} \
             --federated-token ${{ steps.idtoken.outputs.id_token }}
 
-          PYTHON_VERSION="$(cat .python-version)"
-          echo "Installing python $PYTHON_VERSION"
-          pyenv install "$PYTHON_VERSION"
-          pyenv local "$PYTHON_VERSION"
-
           echo "Installing uv"
-          pip install uv
+          curl -LsSf https://astral.sh/uv/install.sh | sh
 
           echo "Running workload"
           state=${{ inputs.state }} \

--- a/.github/workflows/run-workload.yaml
+++ b/.github/workflows/run-workload.yaml
@@ -25,35 +25,67 @@ on:
 
 jobs:
   run-workload:
-    runs-on: cfa-cdcgov
+    permissions:
+          id-token: write # This is required for requesting the JWT
+          contents: read  # This is required for actions/checkout
+    runs-on: ubuntu-latest
     environment: production
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      with:
-        enable-cache: true
+    # From: https://stackoverflow.com/a/58035262/2097171
+    - name: Extract branch name
+      shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      id: get-branch
 
-    - name: "Set up Python"
-      uses: actions/setup-python@v5
+    # From: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#requesting-the-jwt-using-the-actions-core-toolkit
+    - name: Install OIDC Client from Core Package
+      run: npm install @actions/core@1.6.0 @actions/http-client
+    - name: Get Id Token
+      uses: actions/github-script@v7
+      id: idtoken
       with:
-        python-version-file: ".python-version"
+        script: |
+          const coredemo = require('@actions/core')
+          const id_token = await coredemo.getIDToken('api://AzureADTokenExchange')
+          coredemo.setOutput('id_token', id_token)
 
-    - name: Azure Service Principal CLI login
-      uses: azure/login@v2
+    - name: Run workload
+      uses: CDCgov/cfa-actions/runner-action@v1.3.0
       with:
-        creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+        github_app_id: ${{ secrets.CDCENT_ACTOR_APP_ID }}
+        github_app_pem: ${{ secrets.CDCENT_ACTOR_APP_PEM }}
+        wait_for_completion: true
+        print_logs: true
+        script: |
+          CURRENT_BRANCH="${{ steps.get-branch.outputs.branch }}"
+          echo "Cloning repo at branch '$CURRENT_BRANCH'"
+          git clone -b "$CURRENT_BRANCH" https://github.com/${{ github.repository }}.git
+          cd cfa-config-generator
 
-    - name: Execute workload script
-      run: |
-        state=${{ inputs.state }} \
-        disease=${{ inputs.disease }} \
-        reference_dates=${{ inputs.reference_dates }} \
-        report_date=${{ inputs.report_date }} \
-        data_container=${{ inputs.data_container }} \
-        production_date=${{ inputs.production_date }} \
-        job_id=${{ inputs.job_id }} \
-        task_exclusions=${{ inputs.task_exclusions }} \
-        output_container=${{ inputs.output_container }} \
-          uv run python pipelines/epinow2/generate_config.py
+          echo "Logging into Azure CLI"
+          az login --output none --service-principal \
+            --username ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP_CLIENT_ID }} \
+            --tenant ${{ secrets.AZ_TENANT_ID }} \
+            --federated-token ${{ steps.idtoken.outputs.id_token }}
+
+          PYTHON_VERSION="$(cat .python-version)"
+          echo "Installing python $PYTHON_VERSION"
+          pyenv install "$PYTHON_VERSION"
+          pyenv local "$PYTHON_VERSION"
+
+          echo "Installing uv"
+          pip install uv
+
+          echo "Running workload"
+          state=${{ inputs.state }} \
+          disease=${{ inputs.disease }} \
+          reference_dates=${{ inputs.reference_dates }} \
+          report_date=${{ inputs.report_date }} \
+          data_container=${{ inputs.data_container }} \
+          production_date=${{ inputs.production_date }} \
+          job_id=${{ inputs.job_id }} \
+          task_exclusions=${{ inputs.task_exclusions }} \
+          output_container=${{ inputs.output_container }} \
+            uv run python pipelines/epinow2/generate_config.py


### PR DESCRIPTION
Based on the feedback from #52, I was able to rewrite the workloads to run entirely via the runner-action which eliminates the containter app job altogether and even skips the Github Artifact step from #50. I did install `pyenv ` in the self-hosted runner image to make this work, but I think that's a justifiable considering how many workflows are relying on python.

Successfully ran run-workload.yaml: https://github.com/CDCgov/cfa-config-generator/actions/runs/14091957948/job/39470557263

I did run the re-run-workload.yaml, but I don't know how to verify if it worked or not: https://github.com/CDCgov/cfa-config-generator/actions/runs/14092263286/job/39471586566