### PR TITLE
make RSV first class citizen

### DIFF
--- a/src/cfa_config_generator/utils/epinow2/constants.py
+++ b/src/cfa_config_generator/utils/epinow2/constants.py
@@ -72,7 +72,7 @@ all_states = [
 ]
 
 nssp_states_omit = ["AS", "FM", "MH", "NP", "PR", "PW", "VI", "MO", "GU"]
-all_diseases = ["COVID-19", "Influenza"]
+all_diseases = ["COVID-19", "Influenza", "RSV"]
 data_sources = ["nhsn", "nssp"]
 
 azure_storage = {

--- a/src/cfa_config_generator/utils/epinow2/functions.py
+++ b/src/cfa_config_generator/utils/epinow2/functions.py
@@ -219,7 +219,7 @@ def validate_args(
             for ind_disease in disease_excl:
                 if ind_disease not in all_diseases:
                     raise ValueError(
-                        f"Disease {ind_disease} not recognized. Valid options are 'COVID-19' or 'Influenza'"
+                        f"Disease {ind_disease} not recognized. Valid options are 'COVID-19', 'Influenza', or 'RSV'."
                     )
             args_dict["task_exclusions"] = {
                 "geo_value": state_excl,
@@ -240,7 +240,7 @@ def validate_args(
         args_dict["disease"] = all_diseases
     elif disease not in all_diseases:
         raise ValueError(
-            f"Disease {disease} not recognized. Valid options are 'COVID-19' or 'Influenza'."
+            f"Disease {disease} not recognized. Valid options are 'COVID-19', 'Influenza', or 'RSV'."
         )
     else:
         args_dict["disease"] = [disease]

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -161,7 +161,7 @@ def test_invalid_disease_exclusion():
     """Tests that an invalid disease raises a ValueError."""
     today = date.today()
     as_of_date = generate_timestamp()
-    # valid diseases are 'COVID-19' or 'Influenza'
+    # valid diseases are 'COVID-19', 'Influenza', or 'RSV'
     task_exclusions = "WA:mpox"
 
     with pytest.raises(ValueError, match="Disease mpox not recognized"):

--- a/tests/test_exclusions.py
+++ b/tests/test_exclusions.py
@@ -28,7 +28,7 @@ OH,Influenza,2025-01-01,2025-01-01"""
 
 
 def test_exclusions():
-    """Tests that two disease pairs of exclusion generates 100 configs."""
+    """Tests that two disease pairs of exclusion generates 150 configs."""
     report_date = production_date = date.today()
     as_of_date = generate_timestamp()
     max_reference_date = report_date - timedelta(days=1)
@@ -44,17 +44,17 @@ def test_exclusions():
         production_date=production_date,
         job_id="test-job-id",
         as_of_date=as_of_date,
-        task_exclusions="ID:COVID-19,WA:Influenza",
+        task_exclusions="ID:COVID-19,WA:Influenza,OH:RSV",
         output_container="test-container",
         exclusions=None,
     )
     task_configs, _ = generate_task_configs(**validated_args)
-    remaining_configs = 100
+    remaining_configs = 150
     assert len(task_configs) == remaining_configs
 
 
 def test_single_exclusion():
-    """Tests that a single disease pair exclusion generates 101 configs."""
+    """Tests that a single disease pair exclusion generates 152 configs."""
 
     report_date = production_date = date.today()
     as_of_date = generate_timestamp()
@@ -76,7 +76,7 @@ def test_single_exclusion():
         exclusions=None,
     )
     task_configs, _ = generate_task_configs(**validated_args)
-    remaining_configs = 101
+    remaining_configs = 152
     assert len(task_configs) == remaining_configs
 
 


### PR DESCRIPTION
## Nate's Summary
Thankfully a fairly simple process. Did a global search (case insensitive) for "COVID" and for "flu", and fixed up everywhere required. Also fixed the failing tests these changes introduced.

## Copilot's Summary
This pull request introduces support for the disease "RSV" in the configuration generator and updates related validation and test cases to reflect this addition. The most important changes include updating constants, modifying validation logic, and adjusting test cases to account for the new disease.

### Updates to constants:
* Added "RSV" to the `all_diseases` list in `src/cfa_config_generator/utils/epinow2/constants.py`.

### Validation logic updates:
* Updated error messages in `validate_args` to include "RSV" as a valid disease option in `src/cfa_config_generator/utils/epinow2/functions.py`. [[1]](diffhunk://#diff-ab59143b1ba343d18c0ed85e6e50cacaa76d64fad93c142b8f349b5e61db04f8L222-R222) [[2]](diffhunk://#diff-ab59143b1ba343d18c0ed85e6e50cacaa76d64fad93c142b8f349b5e61db04f8L243-R243)

### Test case updates:
* Adjusted comments and expected values in `tests/test_args.py` to include "RSV" as a valid disease.
* Updated `tests/test_exclusions.py` to reflect the increased number of generated configurations due to the addition of "RSV". Specifically:
  - Changed the expected number of configs in `test_exclusions` from 100 to 150 and updated task exclusions. [[1]](diffhunk://#diff-542cfd86872c0274c50b531464176db1730d5384554605a0679a7975e2f5e41cL31-R31) [[2]](diffhunk://#diff-542cfd86872c0274c50b531464176db1730d5384554605a0679a7975e2f5e41cL47-R57)
  - Changed the expected number of configs in `test_single_exclusion` from 101 to 152.