### PR TITLE
Return the job ids for use later

### DIFF
--- a/src/cfa_config_generator/utils/epinow2/driver_functions.py
+++ b/src/cfa_config_generator/utils/epinow2/driver_functions.py
@@ -336,7 +336,7 @@ def generate_backfill_config(
     as_of_dates: list[str],
     output_container: str,
     task_exclusions: str | None = None,
-):
+) -> list[str]:
     """
     This function can be seen a like a loop over generate_config for a number of report
     dates.
@@ -388,6 +388,12 @@ def generate_backfill_config(
         Blob storage container to store output.
     task_exclusions: str | None
         Comma separated state:disease pair to exclude from model run.
+
+    Returns
+    -------
+    list[str]
+        A list of job IDs for each report date in the backfill run. This is also written
+        to the metadata file in the config storage container.
     """
     # === Set up =======================================================================
     if not len(report_dates) == len(data_paths) == len(as_of_dates):
@@ -485,3 +491,5 @@ def generate_backfill_config(
     logger.info(
         f"Successfully wrote metadata file to {metadata_path} in {azure_storage['azure_container_name']}."
     )
+
+    return job_ids


### PR DESCRIPTION
## Nate's Summary
Return the job ids that are generated for this backfill run. Useful for consumers to be able to easily find the configs after they've been generated.

## Copilot's Summary
This pull request updates the `generate_backfill_config` function in `src/cfa_config_generator/utils/epinow2/driver_functions.py` to include a return type annotation, a detailed description of the return value in the docstring, and a return statement for the list of job IDs.

### Changes to `generate_backfill_config` function:

* **Type Annotation**: Added a return type annotation `-> list[str]` to specify that the function returns a list of strings.
* **Docstring Update**: Expanded the docstring to include a "Returns" section, describing that the function returns a list of job IDs for each report date in the backfill run.
* **Return Statement**: Added a `return job_ids` statement at the end of the function to ensure the list of job IDs is returned.