### PR TITLE
removed MO from state exclusions list

### DIFF
--- a/src/cfa_config_generator/utils/epinow2/constants.py
+++ b/src/cfa_config_generator/utils/epinow2/constants.py
@@ -71,7 +71,7 @@ all_states = (
     "US",
 )
 
-nssp_states_omit = ("AS", "FM", "MH", "NP", "PR", "PW", "VI", "MO", "GU")
+nssp_states_omit = ("AS", "FM", "MH", "NP", "PR", "PW", "VI", "GU")
 nssp_valid_states = tuple(set(all_states).difference(nssp_states_omit))
 all_diseases = ("COVID-19", "Influenza", "RSV")
 data_sources = ("nhsn", "nssp")

--- a/tests/test_exclusions.py
+++ b/tests/test_exclusions.py
@@ -49,7 +49,7 @@ def test_exclusions():
         exclusions=None,
     )
     task_configs, _ = generate_task_configs(**validated_args)
-    remaining_configs = 150
+    remaining_configs = 153
     assert len(task_configs) == remaining_configs
 
 
@@ -76,7 +76,7 @@ def test_single_exclusion():
         exclusions=None,
     )
     task_configs, _ = generate_task_configs(**validated_args)
-    remaining_configs = 152
+    remaining_configs = 155
     assert len(task_configs) == remaining_configs
 
 


### PR DESCRIPTION
This change removes Missouri from the list of states that we excluded from our pipeline run and adjusts the test length in the test_exclusions python file