### PR TITLE
Gio return config

### DIFF
--- a/pipelines/epinow2/generate_local_config.py
+++ b/pipelines/epinow2/generate_local_config.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Any
+
+from cfa_config_generator.utils.epinow2.driver_functions import generate_local_config
+from cfa_config_generator.utils.epinow2.functions import (
+    extract_user_args,
+    generate_timestamp,
+)
+
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    # Generate job-specific parameters
+    as_of_date: str = generate_timestamp()
+
+    # Pull run parameters from environment
+    user_args: dict[str, Any] = extract_user_args(as_of_date=as_of_date)
+
+    generate_local_config(
+        state=user_args["state"],
+        disease=user_args["disease"],
+        report_date=user_args["report_date"],
+        reference_dates=user_args["reference_dates"],
+        data_path=user_args["data_path"],
+        data_container=user_args["data_container"],
+        production_date=user_args["production_date"],
+        job_id=user_args["job_id"],
+        as_of_date=user_args["as_of_date"],
+        output_container=user_args["output_container"],
+        task_exclusions=user_args.get("task_exclusions"),
+        exclusions=user_args.get("exclusions"),
+        facility_active_proportion=user_args["facility_active_proportion"],
+    )

--- a/src/cfa_config_generator/utils/azure/auth.py
+++ b/src/cfa_config_generator/utils/azure/auth.py
@@ -1,18 +1,17 @@
-from azure.identity import AzureCliCredential
+from azure.identity import DefaultAzureCredential
 
 
-def obtain_sp_credential() -> AzureCliCredential:
+def obtain_sp_credential() -> DefaultAzureCredential:
     """Obtains service principal credentials from Azure.
     Returns:
-        Instance of AzureCliCredential.
+        Instance of DefaultAzureCredential.
     Raises:
         LookupError if credential not found.
     """
 
-    # The AzureCliCredential reads from the environment directly
-    # if running locally. Check that SP credentials
-    # are in environment if running locally.
-    # Deployed versions use Managed Identity.
-    sp_credential = AzureCliCredential()
+    # The DefaultAzureCredential reads from the environment directly
+    # see the docs for credential ordering
+    # https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python
+    credential = DefaultAzureCredential()
 
-    return sp_credential
+    return credential

--- a/src/cfa_config_generator/utils/epinow2/driver_functions.py
+++ b/src/cfa_config_generator/utils/epinow2/driver_functions.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from datetime import date
 
 import polars as pl
@@ -28,6 +29,96 @@ from cfa_config_generator.utils.epinow2.functions import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def generate_local_config(
+    state: str,
+    disease: str,
+    report_date: date,
+    reference_dates: tuple[date, date],
+    data_path: str,
+    data_container: str,
+    production_date: date,
+    job_id: str,
+    as_of_date: str,
+    output_container: str,
+    facility_active_proportion: float,
+    task_exclusions: str | None = None,
+    exclusions: dict | None = None,
+):
+    """
+    A function to generate `epinow2` configuration objects based on provided arguments.
+    This function validates the arguments, generates configuration objects,
+    and writes them to Blob Storage.
+
+    Parameters
+    ----------
+    state: str
+        Geography to run model
+    disease: str
+        Disease to run
+    report_date: date
+        Date of snapshot to use for model run
+    reference_dates: tuple[date, date]
+        Length two tuple of the minimum and maximum reference (event) dates
+    data_path: str
+        Path to input data
+    data_container: str
+        Blob storage container for input data
+    production_date: date
+        Production date of model run
+    job_id: str
+        Unique identifier for job
+    as_of_date: str
+        ISO format timestamp specifying the timestamp as of which to fetch
+        the parameters for. This should usually be the same as the report date.
+    output_container: str
+        Blob storage container to store output
+    task_exclusions: str | None
+        Comma separated state:disease pair to exclude from model run
+    exclusions: dict | None
+        Dictionary with keys 'path' and 'blob_storage_container' for the exclusions file.
+        If provided, this will be used to generate the task exclusions string.
+    facility_active_proportion: float
+        Minimum proportion of days a facility must be active during the modeling period.
+        Must be a number between 0 and 1 (inclusive).
+
+    Returns
+    -------
+    None
+        The function writes the generated configuration objects to Blob Storage.
+
+    Raises
+    ------
+    ValueError
+        If the report_dates and reference_dates are not the same length.
+    LookupError
+        If there is an error obtaining the storage client.
+    ValueError
+        If there is an error pushing the configuration objects to Azure Blob Storage.
+    Exception
+        If there is an error during the process.
+    """
+    # Validate and sanitize args directly
+    sanitized_args = validate_args(
+        state=state,
+        disease=disease,
+        report_date=report_date,
+        reference_dates=reference_dates,
+        data_path=data_path,
+        data_container=data_container,
+        production_date=production_date,
+        job_id=job_id,
+        as_of_date=as_of_date,
+        output_container=output_container,
+        task_exclusions=task_exclusions,
+        exclusions=exclusions,
+        facility_active_proportion=facility_active_proportion,
+    )
+
+    # Generate task-specific configs
+    task_configs, generated_job_id = generate_task_configs(**sanitized_args)
+    return task_configs
 
 
 def generate_config(
@@ -149,6 +240,29 @@ def generate_config(
         f"Successfully generated configs for job; tasks stored in {generated_job_id} directory."
     )
     return task_configs
+
+
+def create_task_files(task_configs: list[dict], generated_job_id: str):
+    """Creates a directory in 'dist' named after generated_job_id and generates JSON files."""
+    # Define the base directory
+    base_dir = os.path.join("dist", generated_job_id)
+
+    # Ensure the directory exists
+    os.makedirs(base_dir, exist_ok=True)
+
+    for task_config in task_configs:
+        # Get task_id and construct file path
+        task_id = task_config.get("task_id")
+        if task_id:  # Ensure task_id exists
+            file_path = os.path.join(base_dir, f"{task_id}.json")
+
+            # Write JSON file
+            with open(file_path, "w") as json_file:
+                json.dump(task_config, json_file, indent=4)
+
+    print(f"Generated {len(task_configs)} JSON files in directory:")
+    print(f"{base_dir}")
+    return base_dir
 
 
 def generate_rerun_config(

--- a/src/cfa_config_generator/utils/epinow2/driver_functions.py
+++ b/src/cfa_config_generator/utils/epinow2/driver_functions.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from datetime import date
 
 import polars as pl

--- a/src/cfa_config_generator/utils/epinow2/driver_functions.py
+++ b/src/cfa_config_generator/utils/epinow2/driver_functions.py
@@ -148,6 +148,7 @@ def generate_config(
     logger.info(
         f"Successfully generated configs for job; tasks stored in {generated_job_id} directory."
     )
+    return task_configs
 
 
 def generate_rerun_config(

--- a/src/cfa_config_generator/utils/epinow2/driver_functions.py
+++ b/src/cfa_config_generator/utils/epinow2/driver_functions.py
@@ -4,7 +4,7 @@ import os
 from datetime import date
 
 import polars as pl
-from azure.identity import AzureCliCredential, DefaultAzureCredential
+from azure.identity import DefaultAzureCredential
 from azure.storage.blob import (
     BlobClient,
     BlobServiceClient,
@@ -211,9 +211,9 @@ def generate_config(
 
     # Push task configs to Azure Blob Storage
     try:
-        sp_credential: AzureCliCredential = obtain_sp_credential()
+        credential: DefaultAzureCredential = obtain_sp_credential()
         storage_client: BlobServiceClient = instantiate_blob_service_client(
-            sp_credential=sp_credential,
+            sp_credential=credential,
             account_url=azure_storage["azure_storage_account_url"],
         )
         container_client = storage_client.get_container_client(

--- a/src/cfa_config_generator/utils/epinow2/driver_functions.py
+++ b/src/cfa_config_generator/utils/epinow2/driver_functions.py
@@ -242,29 +242,6 @@ def generate_config(
     return task_configs
 
 
-def create_task_files(task_configs: list[dict], generated_job_id: str):
-    """Creates a directory in 'dist' named after generated_job_id and generates JSON files."""
-    # Define the base directory
-    base_dir = os.path.join("dist", generated_job_id)
-
-    # Ensure the directory exists
-    os.makedirs(base_dir, exist_ok=True)
-
-    for task_config in task_configs:
-        # Get task_id and construct file path
-        task_id = task_config.get("task_id")
-        if task_id:  # Ensure task_id exists
-            file_path = os.path.join(base_dir, f"{task_id}.json")
-
-            # Write JSON file
-            with open(file_path, "w") as json_file:
-                json.dump(task_config, json_file, indent=4)
-
-    print(f"Generated {len(task_configs)} JSON files in directory:")
-    print(f"{base_dir}")
-    return base_dir
-
-
 def generate_rerun_config(
     state: str,
     disease: str,

--- a/src/cfa_config_generator/utils/epinow2/driver_functions.py
+++ b/src/cfa_config_generator/utils/epinow2/driver_functions.py
@@ -45,11 +45,11 @@ def generate_local_config(
     facility_active_proportion: float,
     task_exclusions: str | None = None,
     exclusions: dict | None = None,
-):
+) -> tuple[list[dict], str]:
     """
     A function to generate `epinow2` configuration objects based on provided arguments.
     This function validates the arguments, generates configuration objects,
-    and writes them to Blob Storage.
+    and returns them.
 
     Parameters
     ----------
@@ -85,8 +85,8 @@ def generate_local_config(
 
     Returns
     -------
-    None
-        The function writes the generated configuration objects to Blob Storage.
+     tuple[list[dict], str]
+        The function returns the generated configuration objects and the `job_id`.
 
     Raises
     ------


### PR DESCRIPTION
This PR does three things:
1. adds a generate_local_config function that returns the generated configs without uploading to azure
2. returns the generated configs from generate_configs()
3. uses the DefaultAzureCredential instead of AzureCliCredential

These changes allow the library to be used without accessing Azure, and enable Azure use via managed identities. This will streamline Dagster for Rt pipeline: https://github.com/CDCgov/cfa-epinow2-pipeline/pull/378